### PR TITLE
fix: use notifyPropertyChange instead of propertyDidChange (fixes #89)

### DIFF
--- a/addon/mixins/parent-component-support.js
+++ b/addon/mixins/parent-component-support.js
@@ -27,7 +27,16 @@ export default Mixin.create({
   },
 
   _fireComposableChildrenChanged() {
-    this.propertyDidChange('composableChildren');
+    if (typeof this.notifyPropertyChange === 'function') {
+      this.notifyPropertyChange('composableChildren');
+    }
+    else if (typeof this.propertyDidChange === 'function') {
+      // Deprecated in ember 3.1
+      this.propertyDidChange('composableChildren');
+    }
+    else {
+      throw new Error('Unable to call notifyPropertyChange');
+    }
   },
 
   _notifyComposableChildrenChanged() {


### PR DESCRIPTION
Use of [private API method `propertyDidChange`](https://www.emberjs.com/api/ember/3.5/classes/EmberObject/methods/propertyDidChange?anchor=propertyDidChange&show=inherited%2Cprivate) has been [deprecated since 3.1](https://emberjs.com/blog/2018/04/13/ember-3-1-released.html#toc_deprecations-in-ember-3-1) and now breaks in 3.7. 

Closes #89