### PR TITLE
fix: set during init instead of overwriting computed property

### DIFF
--- a/addon/mixins/child-component-support.js
+++ b/addon/mixins/child-component-support.js
@@ -1,5 +1,4 @@
 import { assert } from '@ember/debug';
-import { computed } from '@ember/object';
 import Mixin from '@ember/object/mixin';
 
 export default Mixin.create({
@@ -10,16 +9,13 @@ export default Mixin.create({
       this.get('_parentComponentTypes')
     );
     this._registerWithParent();
+    this.set('composableParent', this._componentToRegisterTo());
   },
 
   willDestroyElement() {
     this._unregisterWithParent();
     this._super(...arguments);
   },
-
-  composableParent: computed(function() {
-    return this._componentToRegisterTo();
-  }),
 
   _componentToRegisterTo() {
     let c = null;


### PR DESCRIPTION
Fixes #145 and seems to work in my application, but I would feel better if someone reviewed it. I don't understand the reason why (1) a computed property was defined with no dependent keys rather than initializing it [for lazy-loading / performance?] and (2) why that CP gets overwritten later.

I tried changing it so that it used another property as its dependent key and then defined a setter that set that underlying value and a getter that returned the underlying value or the result of `this._componentToRegisterTo()` but was surprised to find that this didn't seem to work. 
