### PR TITLE
fix: don't call Ember.A as a constructor 

### DIFF
--- a/addon/mixins/parent-component-support.js
+++ b/addon/mixins/parent-component-support.js
@@ -19,7 +19,7 @@ export default Mixin.create({
 
   getComposableChildren() {
     let comps = this.get('_childComponents');
-    return new A(comps && comps.size ? this.get('_childComponents').list : []);
+    return A(comps && comps.size ? this.get('_childComponents').list : []);
   },
 
   _fireComposableChildrenChanged() {


### PR DESCRIPTION
Closes #179